### PR TITLE
Add support for dotted container names

### DIFF
--- a/main.go
+++ b/main.go
@@ -295,7 +295,7 @@ func sourceAddrForPort(port int, dest *net.TCPAddr) *net.TCPAddr {
 	return getSourceAddr(addr)
 }
 
-var dnsNameAllowedChars = regexp.MustCompile(`[^-a-z0-9]+`)
+var dnsNameAllowedChars = regexp.MustCompile(`[^-a-z0-9.]+`)
 var dnsNameHyphenStrings = regexp.MustCompile(`-{2,}`)
 
 func dnsNameFromContainerName(containerName string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ func TestDnsNameFromContainerName(t *testing.T) {
 	expectations := []stringFuncExpectation{
 		stringFuncExpectation{in: "pharod_db_1", expects: "pharod-db-1"},
 		stringFuncExpectation{in: "/pharod_db_1__", expects: "pharod-db-1"},
-		stringFuncExpectation{in: "/pharod_db__1.yes", expects: "pharod-db-1-yes"},
+		stringFuncExpectation{in: "/pharod_db__1.yes", expects: "pharod-db-1.yes"},
 		stringFuncExpectation{in: "ph!@£$arod_db_1", expects: "ph-arod-db-1"},
 	}
 


### PR DESCRIPTION
Preserving dots in dotted container names so that subdomains can be used, e.g. `this.that` which will become `this.that.pharod`